### PR TITLE
Rename issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,4 @@
+---
 name: Annotation toolkit bug report
 about: Is something not working as expected on the annotation toolkit? Let us know!
 title: "[Bug] "
@@ -36,3 +37,4 @@ body:
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
+---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,3 +1,4 @@
+---
 name: Annotation toolkit feature request
 about: Request an addition to the annotation toolkit.
 title: "[Feature request] "
@@ -36,3 +37,4 @@ body:
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
+---

--- a/.github/ISSUE_TEMPLATE/license-question.md
+++ b/.github/ISSUE_TEMPLATE/license-question.md
@@ -1,3 +1,4 @@
+---
 name: License question
 about: Have a question about our open source license?
 title: "[License] "
@@ -29,3 +30,4 @@ body:
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
+---


### PR DESCRIPTION
This PR:

- Renames issue templates to use `.md` in place of `.yml`
- Adds code fences (`---`) to the Markdown's YAML frontmatter