### PR TITLE
Update mobile annotations for Titles and Headings

### DIFF
--- a/tutorials/mobile-annotations.md
+++ b/tutorials/mobile-annotations.md
@@ -68,10 +68,10 @@ The Grouping Stamp is the cornerstone of mobile annotations. It is used to highl
 
 Text marked as a **Heading** will help users understand the purpose of a section. Screen readers users can also to navigate quickly between sections of a view based on headings and other elements. 
 
-**Titles** are announced after transitioning to a view and should be placed toward the top. They are similar to `<h1>` headings on web experiences, helping users orient and understand the purpose of the content.
+**Titles** are announced after transitioning to a view and are typically in the [top app bar](https://m3.material.io/components/app-bars/overview) or [toolbar](https://developer.apple.com/design/human-interface-guidelines/toolbars) with other elements such as the back button. They are similar to `<h1>` headings on web experiences, helping users orient and understand the purpose of the content.
 
 > [!CAUTION]
-> Headings and Titles are optional and it’s common for views to not have either one. Only use headings when they truly help illuminate the structure of a screen.
+> Headings are optional and it’s common for views to not have either one. Only use headings when they truly help illuminate the structure of a screen.
 
 <img src="Images/mobile-stamp-annotations.png" alt="Two annotations: one is a dark cyan mobile pin stamp with a label of Heading. The second is a dark cyan mobile bracket stamp with a label of Title." width="679">
 


### PR DESCRIPTION
Clarified the placement of Titles in mobile views and emphasized their typical location in the app bar or toolbar.