### PR TITLE
Fix typo in author name

### DIFF
--- a/checklists/engineering-checklist.md
+++ b/checklists/engineering-checklist.md
@@ -121,7 +121,7 @@ If you don't have a designer on your project, or are not working with an accessi
 
 ### Resources
 - [Form Pattern Documentation - Primer](https://primer.style/product/ui-patterns/forms/)
-- [Structuring Accessible Forms - Rachel DiTullio](https://racheleditullio.com/blog/2021/09/structuring-accessible-forms/)
+- [Structuring Accessible Forms - Rachele DiTullio](https://racheleditullio.com/blog/2021/09/structuring-accessible-forms/)
 
 
 ---

--- a/tutorials/form-element.md
+++ b/tutorials/form-element.md
@@ -217,7 +217,7 @@ If additional information needs to be added to a Label, Hint, Legend, or any oth
 - [​Form pattern documentation - Primer](https://primer.style/product/ui-patterns/forms/)
 - [Forms Tutorial - W3C Web Accessibility Initiative](https://www.w3.org/WAI/tutorials/forms/)
 - [Create accessible forms - A11y Project](https://www.a11yproject.com/posts/how-to-write-accessible-forms/)
-- [Structuring Accessible Forms - Rachel DiTullio](https://racheleditullio.com/blog/2021/09/structuring-accessible-forms/)
+- [Structuring Accessible Forms - Rachele DiTullio](https://racheleditullio.com/blog/2021/09/structuring-accessible-forms/)
 - [Creating Accessible Forms - WebAIM](https://webaim.org/techniques/forms/controls)
 - [Don’t use the placeholder attribute - Smashing Magazine](https://www.smashingmagazine.com/2018/06/placeholder-attribute/)
 - [Provide helpful error messages - Harvard University](https://accessibility.huit.harvard.edu/provide-helpful-error-messages)


### PR DESCRIPTION
A minor fix to resource links in the form elements tutorial and engineering checklist to correct the spelling of an author's name. Hat tip to @julianmka for catching it. 