### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Keep small changes brief. Remove optional sections that do not apply.
+Do not include confidential designs or other sensitive information.
+Figma library changes follow the separate process in the contribution guide: https://github.com/github/annotation-toolkit/blob/main/CONTRIBUTING.md
+-->
+
+## Summary
+
+<!-- Describe what changes and why. Include supporting sources when they help explain changes to guidance. -->
+
+## Related issues (optional)
+
+<!-- Link to related issues. Use "Closes #..." only when this pull request resolves the issue. -->
+
+## Review notes (optional)
+
+<!--
+Describe what you checked, any limitations, and where reviewers should focus.
+For documentation changes, consider rendered Markdown, links, images, and the accuracy of guidance.
+Add screenshots or recordings only when they help explain the change. Include a written explanation, not only visual evidence.
+-->
+
+## Checklist
+
+- [ ] New and updated images in the changed files and this description have descriptive alt text (or there are no image changes).
+- [ ] This contribution follows the [Code of Conduct](https://github.com/github/annotation-toolkit/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Contributors need consistent prompts for describing repository changes and giving reviewers context. Add a lightweight default template for documentation-focused contributions, with optional related issues and review notes and the existing issue forms' alt-text and Code of Conduct acknowledgements.

## Related issues (optional)

N/A

## Review notes (optional)

Author guidance stays in HTML comments. The template avoids release and CI requirements, preserves the separate Figma contribution process, and becomes active after merge into `main`.

## Checklist

- [x] New and updated images in the changed files and this description have descriptive alt text (or there are no image changes).
- [x] This contribution follows the [Code of Conduct](https://github.com/github/annotation-toolkit/blob/main/CODE_OF_CONDUCT.md).